### PR TITLE
Change Jetty version from 11 to 9 to fix servlets.

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jetty.version>11.0.0</jetty.version>
+    <jetty.version>9.4.31.v20200723</jetty.version>
 
     <!-- Project-specific properties -->
     <exec.mainClass>com.google.sps.ServerMain</exec.mainClass>

--- a/walkthroughs/week-1-web-development/examples/stanley/pom.xml
+++ b/walkthroughs/week-1-web-development/examples/stanley/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jetty.version>11.0.0</jetty.version>
+    <jetty.version>9.4.31.v20200723</jetty.version>
 
     <!-- Project-specific properties -->
     <exec.mainClass>com.google.sps.ServerMain</exec.mainClass>

--- a/walkthroughs/week-2-server/examples/form-submission/pom.xml
+++ b/walkthroughs/week-2-server/examples/form-submission/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jetty.version>11.0.0</jetty.version>
+    <jetty.version>9.4.31.v20200723</jetty.version>
 
     <!-- Project-specific properties -->
     <exec.mainClass>com.google.sps.ServerMain</exec.mainClass>

--- a/walkthroughs/week-2-server/examples/page-view-counter/pom.xml
+++ b/walkthroughs/week-2-server/examples/page-view-counter/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jetty.version>11.0.0</jetty.version>
+    <jetty.version>9.4.31.v20200723</jetty.version>
 
     <!-- Project-specific properties -->
     <exec.mainClass>com.google.sps.ServerMain</exec.mainClass>

--- a/walkthroughs/week-2-server/examples/server-date/pom.xml
+++ b/walkthroughs/week-2-server/examples/server-date/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jetty.version>11.0.0</jetty.version>
+    <jetty.version>9.4.31.v20200723</jetty.version>
 
     <!-- Project-specific properties -->
     <exec.mainClass>com.google.sps.ServerMain</exec.mainClass>

--- a/walkthroughs/week-2-server/examples/server-stats/pom.xml
+++ b/walkthroughs/week-2-server/examples/server-stats/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jetty.version>11.0.0</jetty.version>
+    <jetty.version>9.4.31.v20200723</jetty.version>
 
     <!-- Project-specific properties -->
     <exec.mainClass>com.google.sps.ServerMain</exec.mainClass>

--- a/walkthroughs/week-2-server/examples/text-processor/pom.xml
+++ b/walkthroughs/week-2-server/examples/text-processor/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jetty.version>11.0.0</jetty.version>
+    <jetty.version>9.4.31.v20200723</jetty.version>
 
     <!-- Project-specific properties -->
     <exec.mainClass>com.google.sps.ServerMain</exec.mainClass>

--- a/walkthroughs/week-3-libraries/charts/examples/bigfoot-sightings/pom.xml
+++ b/walkthroughs/week-3-libraries/charts/examples/bigfoot-sightings/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jetty.version>11.0.0</jetty.version>
+    <jetty.version>9.4.31.v20200723</jetty.version>
 
     <!-- Project-specific properties -->
     <exec.mainClass>com.google.sps.ServerMain</exec.mainClass>

--- a/walkthroughs/week-3-libraries/charts/examples/favorite-colors/pom.xml
+++ b/walkthroughs/week-3-libraries/charts/examples/favorite-colors/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jetty.version>11.0.0</jetty.version>
+    <jetty.version>9.4.31.v20200723</jetty.version>
 
     <!-- Project-specific properties -->
     <exec.mainClass>com.google.sps.ServerMain</exec.mainClass>

--- a/walkthroughs/week-3-libraries/charts/examples/hello-world/pom.xml
+++ b/walkthroughs/week-3-libraries/charts/examples/hello-world/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jetty.version>11.0.0</jetty.version>
+    <jetty.version>9.4.31.v20200723</jetty.version>
 
     <!-- Project-specific properties -->
     <exec.mainClass>com.google.sps.ServerMain</exec.mainClass>

--- a/walkthroughs/week-3-libraries/cloud-storage/examples/hello-world/pom.xml
+++ b/walkthroughs/week-3-libraries/cloud-storage/examples/hello-world/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jetty.version>11.0.0</jetty.version>
+    <jetty.version>9.4.31.v20200723</jetty.version>
 
     <!-- Project-specific properties -->
     <exec.mainClass>com.google.sps.ServerMain</exec.mainClass>

--- a/walkthroughs/week-3-libraries/datastore/examples/todo-list/pom.xml
+++ b/walkthroughs/week-3-libraries/datastore/examples/todo-list/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jetty.version>11.0.0</jetty.version>
+    <jetty.version>9.4.31.v20200723</jetty.version>
 
     <!-- Project-specific properties -->
     <exec.mainClass>com.google.sps.ServerMain</exec.mainClass>

--- a/walkthroughs/week-3-libraries/image-analysis/examples/image-analyzer/pom.xml
+++ b/walkthroughs/week-3-libraries/image-analysis/examples/image-analyzer/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jetty.version>11.0.0</jetty.version>
+    <jetty.version>9.4.31.v20200723</jetty.version>
 
     <!-- Project-specific properties -->
     <exec.mainClass>com.google.sps.ServerMain</exec.mainClass>

--- a/walkthroughs/week-3-libraries/maps/examples/google-tour/pom.xml
+++ b/walkthroughs/week-3-libraries/maps/examples/google-tour/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jetty.version>11.0.0</jetty.version>
+    <jetty.version>9.4.31.v20200723</jetty.version>
 
     <!-- Project-specific properties -->
     <exec.mainClass>com.google.sps.ServerMain</exec.mainClass>

--- a/walkthroughs/week-3-libraries/maps/examples/hello-world/pom.xml
+++ b/walkthroughs/week-3-libraries/maps/examples/hello-world/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jetty.version>11.0.0</jetty.version>
+    <jetty.version>9.4.31.v20200723</jetty.version>
 
     <!-- Project-specific properties -->
     <exec.mainClass>com.google.sps.ServerMain</exec.mainClass>

--- a/walkthroughs/week-3-libraries/maps/examples/info-window/pom.xml
+++ b/walkthroughs/week-3-libraries/maps/examples/info-window/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jetty.version>11.0.0</jetty.version>
+    <jetty.version>9.4.31.v20200723</jetty.version>
 
     <!-- Project-specific properties -->
     <exec.mainClass>com.google.sps.ServerMain</exec.mainClass>

--- a/walkthroughs/week-3-libraries/maps/examples/marker-storage/pom.xml
+++ b/walkthroughs/week-3-libraries/maps/examples/marker-storage/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jetty.version>11.0.0</jetty.version>
+    <jetty.version>9.4.31.v20200723</jetty.version>
 
     <!-- Project-specific properties -->
     <exec.mainClass>com.google.sps.ServerMain</exec.mainClass>

--- a/walkthroughs/week-3-libraries/maps/examples/marker/pom.xml
+++ b/walkthroughs/week-3-libraries/maps/examples/marker/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jetty.version>11.0.0</jetty.version>
+    <jetty.version>9.4.31.v20200723</jetty.version>
 
     <!-- Project-specific properties -->
     <exec.mainClass>com.google.sps.ServerMain</exec.mainClass>

--- a/walkthroughs/week-3-libraries/maps/examples/ufos/pom.xml
+++ b/walkthroughs/week-3-libraries/maps/examples/ufos/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jetty.version>11.0.0</jetty.version>
+    <jetty.version>9.4.31.v20200723</jetty.version>
 
     <!-- Project-specific properties -->
     <exec.mainClass>com.google.sps.ServerMain</exec.mainClass>


### PR DESCRIPTION
This pull request changes the Jetty versions of all pom.xml files from 11.0.0 to 9.4.31.v20200723 which will allow the servlets in this project to work correctly.

Jetty 9 uses classes in the javax.servlet package, but Jetty 11 uses a different package name: jakarta.servlet.